### PR TITLE
Add treeId to TreeViewInput::treeOptions addition #103

### DIFF
--- a/TreeView.php
+++ b/TreeView.php
@@ -475,6 +475,7 @@ HTML;
     {
         $this->initTreeView();
         parent::init();
+        $this->initOptions();
     }
 
     /**
@@ -486,7 +487,6 @@ HTML;
             $this->allowNewRoots = false;
         }
         $this->_nodes = $this->query->all();
-        $this->initOptions();
         $this->registerAssets();
         echo $this->renderWidget();
     }


### PR DESCRIPTION
After I pulled #103 request, `TreeViewInput` can not get `$this->treeOptions['id']` for `treeId`, becauser if i need `treeOptions['id']`, need first `parent::run()` then `TreeViewInput::registerInputAssets()`, if I need show attribute `data-krajee-treeinput`, first need `TreeViewInput::registerInputAssets()` then  `parent::run()`
